### PR TITLE
Update devDependencies / Fix JSHint seting

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -9,6 +9,5 @@
   "undef": true,
   "boss": true,
   "eqnull": true,
-  "node": true,
-  "es5": true
+  "node": true
 }

--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
     "test": "grunt test"
   },
   "devDependencies": {
-    "grunt-contrib-jshint": "~0.6.0",
-    "grunt": "~0.4.1"
+    "grunt-contrib-jshint": "~0.8.0",
+    "grunt": "~0.4.2"
   },
   "peerDependencies": {
     "grunt": "~0.4.1"


### PR DESCRIPTION
I updated devDependencies of this project and fixed JSHint setting. Now there is no need to set the "ES5" option explicitly. (cf. http://www.jshint.com/blog/2013-05-07/2-0-0/).
