### PR TITLE
Stop task

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ grunt.initConfig({
 })
 ```
 
+## The "hoodie\_stop" task
+
+This will stop any Hoodie servers started by the 'hoodie' task. No config
+is required.
+
 ## Contributing
 
 Take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).


### PR DESCRIPTION
I needed a way to cleanly kill the hoodie server after running a test suite. This will just kill any child processes started using the 'hoodie' task. I also added a `www` option to let you specify a custom directory to serve the static content from.
