### PR TITLE
[fix] pass pid instead of child process instance to tree-kill

### DIFF
--- a/tasks/hoodie.js
+++ b/tasks/hoodie.js
@@ -32,7 +32,7 @@ module.exports = function (grunt) {
   function killChild() {
     if (!child || killed) { return; }
     killed = true;
-    kill(child, 'SIGTERM');
+    kill(child.pid, 'SIGTERM');
     grunt.log.ok('Killed ' + child.name + '.');
   }
 


### PR DESCRIPTION
It looks like I messed up in my previous PR... ooops. First argument to `kill` should be a `pid` a not a reference to the child process itself.
