### PR TITLE
Add option to run hoodie from a folder other than the cwd

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,27 @@ Default value: `function(config) {}`
 
 A callback that is called when hoodie is up and running. Has one param called `config` which contains the host and port information.
 
+#### options.childProcessOptions
+
+Type: `Object`
+Default value: `{silent: true}`
+
+Allows to pass options to the childProcess.fork where hoodie runs.
+
+```js
+hoodie: {
+  start: {
+    options: {
+      childProcessOptions: {
+        cwd: process.cwd() + '/myapp',
+        env: env
+      }
+    }
+  },
+  stop: {}
+}
+```
+
 ### Usage Example
 
 In this example, the port of [grunt-connect-proxy](https://npmjs.org/package/grunt-connect-proxy) for the `/_api` of hoodie is set after hoodie started.

--- a/tasks/hoodie.js
+++ b/tasks/hoodie.js
@@ -12,7 +12,7 @@ var fork = require('child_process').fork;
 var kill = require('tree-kill');
 
 // hoodie server start script.
-var bin = path.resolve('node_modules/hoodie-server/bin/start');
+var bin = 'node_modules/hoodie-server/bin/start';
 
 module.exports = function (grunt) {
 
@@ -57,7 +57,7 @@ module.exports = function (grunt) {
       args = [ '--www', options.www ];
     }
 
-    child = fork(bin, args, { silent: true });
+    child = fork(bin, args, options.childProcessOptions);
     child.name = 'hoodie (pid: ' + child.pid + ')';
 
     child.once('message', function (msg) {
@@ -72,9 +72,11 @@ module.exports = function (grunt) {
     child.once('exit', function (code, signal) {
       grunt.log.warn(child.name + ' exited. Code: ' + code + ' / Signal: ' + signal);
     });
-    child.stderr.on('data', function (buf) {
-      grunt.log.error(buf);
-    });
+    if (child.stderr) {
+      child.stderr.on('data', function (buf) {
+        grunt.log.error(buf);
+      });
+    }
   }
 
   // Stop the hoodie server.
@@ -85,7 +87,12 @@ module.exports = function (grunt) {
 
   grunt.registerMultiTask('hoodie', 'Start/stop hoodie.', function () {
     var done = this.async();
-    var options = this.options({ callback: function () {} });
+    var options = this.options({
+      callback: function () {},
+      childProcessOptions: {
+        silent: true
+      }
+     });
 
     switch (this.target) {
       case 'start':


### PR DESCRIPTION
~~This is more a feature request than a pull request, because my implementation is just a quick hack.
I want to put this here for discussion though.~~

For the hoodie integration test setup I need to create a new hoodie app and start it from a subfolder, which is why I imagined a `childProcessOptions` option could work.
https://github.com/hoodiehq/hoodie-integration-test/tree/new

Known bugs in my implementation:
- [x] the data folder ist created in the original folder
- [x] Hoodie plugins aren't loaded as the original package.json seems to be used
